### PR TITLE
Link landing page CTA to onboarding

### DIFF
--- a/web/src/LandingPage.jsx
+++ b/web/src/LandingPage.jsx
@@ -37,7 +37,14 @@ function LandingPage() {
       <section className="hero">
         <h1>Course Builder</h1>
         <p>Create, manage, and share interactive courses right from your browser.</p>
-        <a href="#" className="cta" onClick={(e)=>{e.preventDefault(); testApiPreview();}}>Get Started</a>
+        <button
+          type="button"
+          className="cta"
+          style={{ border: 'none', cursor: 'pointer' }}
+          onClick={() => { window.location.href = '/onboarding' }}
+        >
+          Get Started
+        </button>
       </section>
 
       <section className="test-section">


### PR DESCRIPTION
## Summary
- Replace dummy anchor on landing page with button that navigates to `/onboarding`
- Keep call-to-action styling by applying existing `cta` class and removing default button border

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `make lint` *(fails: .venv/bin/pip: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a64124086c83338d063c56255c7b40